### PR TITLE
LuaHelper::getMovieClipEntityFromLuaEntity now works with userdata.

### DIFF
--- a/BaconBox/Helper/Lua/LuaHelper.cpp
+++ b/BaconBox/Helper/Lua/LuaHelper.cpp
@@ -42,7 +42,13 @@ namespace BaconBox {
 			return entity;
 		}
 
-		Console__error("Can't return an entity in LuaHelper::getEntityFromLuaEntity.");
+		if (lua_isuserdata(L, -1)) {
+			MovieClipEntity *entity = reinterpret_cast<MovieClipEntity *>(getPointerFromLuaUserData(L));
+
+			return entity;
+		}
+
+		Console__error("Can't return a MovieClipEntity in LuaHelper::getMovieClipEntityFromLuaEntity.");
 		return NULL;
 	}
 

--- a/BaconBox/Helper/Lua/LuaHelper.cpp
+++ b/BaconBox/Helper/Lua/LuaHelper.cpp
@@ -42,12 +42,6 @@ namespace BaconBox {
 			return entity;
 		}
 
-		if (lua_isuserdata(L, -1)) {
-			MovieClipEntity *entity = reinterpret_cast<MovieClipEntity *>(getPointerFromLuaUserData(L));
-
-			return entity;
-		}
-
 		Console__error("Can't return a MovieClipEntity in LuaHelper::getMovieClipEntityFromLuaEntity.");
 		return NULL;
 	}

--- a/BaconBox/Special/Swig/BaconBox.i
+++ b/BaconBox/Special/Swig/BaconBox.i
@@ -415,10 +415,12 @@ class FlashEngine;
 %}
 
 
-
-   %typecheck(SWIG_TYPECHECK_POINTER)lua_State* {
-      $1 = 1;
-    }
+#define BB_SWIG_TYPECHECK_LOWEST_PRECEDENCE 99999
+	// Using this typecheck for lowest precedence makes it so the "native" functions
+	// will always be outputted before the functions that accept a lua_State.
+	%typecheck(BB_SWIG_TYPECHECK_LOWEST_PRECEDENCE)lua_State* {
+		$1 = 1;
+	}
 
   %typemap(arginit) lua_State* %{
     #ifdef IMPOSSIBLE_MACRO_JUST_TO_SKIP_SWIG_ARG_COUNT_CHECK_I_SHOULD_REALLY_FIND_A_FIX_IN_THE_NEAR_FUTURE


### PR DESCRIPTION
Fixed an issue where

```
self.background = BaconBox.EntityFactory_getMovieClipEntity(name)
self.movieclip:addChild(self.background)
self.movieclip:removeChild(self.background)
```

Would not work since the entity given by EntityFactory_getMovieClipEntity is the userdata and not wrapped in an table.

Please review changes, I'm not used to playing in the Lua side of thing
