### PR TITLE
Made getSymbol and getMovieClipEntity made less prone to crashes.

### DIFF
--- a/BaconBox/EntityFactory.cpp
+++ b/BaconBox/EntityFactory.cpp
@@ -53,7 +53,7 @@ namespace BaconBox {
 	
 	MovieClipEntity *EntityFactory::getMovieClipEntity(const std::string &key, bool autoPlay) {
 		MovieClipEntity * temp = getInstance().internalGetMovieClipEntity(key, autoPlay);
-		if(temp->getSymbol() == NULL){
+		if (temp && temp->getSymbol() == NULL){
 			ResourceManager::addSymbol(key);
 		}
 		return temp; 
@@ -101,9 +101,11 @@ namespace BaconBox {
 			else{
 				entity = getMovieClipEntityFromSubTexture(ResourceManager::getSubTexture(key));
 			}
+#ifdef BB_DEBUG
 			if(!entity){
-				Console__error("EntityFactory::getMovieClipEntity can't return entity with key: " << key);
+				PRLN("[Warning] EntityFactory::getMovieClipEntity() can't return entity with key: " << key);
 			}
+#endif
 			return entity;
 			//		SubTextureInfo* subTex = ResourceManager::getSubTexture(key);
 			//		return getMovieClipEntityFromSubTexture(subTex);

--- a/BaconBox/ResourceManager.cpp
+++ b/BaconBox/ResourceManager.cpp
@@ -708,7 +708,7 @@ namespace BaconBox {
 		std::map<std::string, SubTextureInfo *>::iterator itr = subTextures.find(key);
 		SubTextureInfo * subTex = (itr != subTextures.end()) ? (itr->second) : (NULL);
 		if (!subTex) {
-			Console__error("FATAL : Could not find subtexture in getSubTexture for key: `" << key << "`");
+			return subTex;
 		}
 		if (loadTextureIfNotLoaded && ! subTex->textureInfo->isLoaded()) {
 			loadTexture(subTex->textureInfo);

--- a/BaconBox/ResourceManager.cpp
+++ b/BaconBox/ResourceManager.cpp
@@ -723,6 +723,10 @@ namespace BaconBox {
 		return (itr != symbols.end()) ? (itr->second) : (NULL);
 	}
 
+	bool ResourceManager::symbolExists(const std::string &key) {
+		return ( getSymbol(key) ? true : false );
+	}
+
 	Symbol *ResourceManager::addSymbol(const std::string &key, Symbol * symbol, bool overwrite){
 
 		

--- a/BaconBox/ResourceManager.h
+++ b/BaconBox/ResourceManager.h
@@ -144,6 +144,8 @@ namespace BaconBox {
 
 		static Symbol *addSymbol(const std::string &key, Symbol * symbol = NULL, bool overwrite = false);
 		static Symbol *getSymbol(const std::string &key);
+		/// Checks whether a symbol exists for the given key.
+		static bool symbolExists(const std::string &key);
 		/**
 		 * Gets a pointer to the asked sound effect.
 		 * @param key Name of the sound effect to get a pointer of.


### PR DESCRIPTION
No more null dereferences, but you need to actually check in your code whether you get nil or not before working with said `MovieClip`, in cases where you should get them.
The previous behaviour was a program abort because of a null dereference.

Since I also added `symbolExists()`, it could still stop/throw/abort/??? when a symbol does not exist with the given key (mimicking previous behaviour). The game can still verify existence of symbol before instantiating it.
